### PR TITLE
Update README and fix examples while filtering by Filters list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,46 @@ var newList = query.ToList();
 ];
 ```
 
+#### Filtering using the `Filters` list in `FilterModel`.
+You can also use the `Filters` list in the `FilterModel` to filter the list of entities. <br/>
+The `Filters` list accepts a list of `FilterModel` to filter the list of entities. <br/>
+The following example shows how to filter the list of entities to get only the ones with age greater than or equal to 50 and the name is "John".
+```csharp
+var query = EntityList.AsQueryable();
+var model = new FilterModel<TestEntity>
+		{
+			Operator = FilterOperator.And,
+			Filters =
+			[
+				new FilterModel<TestEntity>
+				{
+					Field = "Age",
+					Operator = FilterOperator.GreaterThanOrEqual,
+					Value = " 50"
+				},
+				new FilterModel<TestEntity>
+				{
+					Field = "Name",
+					Operator = FilterOperator.Equal,
+					Value = "John"
+				}
+			]
+		};
+
+query = query.ApplyFilter(model);
+
+// Apply the .ToList() to get the filtered list
+var newList = query.ToList();
+```
+
+*Returns:*
+```csharp
+[
+	new TestEntity { Id = Guid.NewGuid(), Name = "John", LastName = "Thomas", Age = 55, CreatedDateUtc = DateTime.UtcNow },
+	new TestEntity { Id = Guid.NewGuid(), Name = "John", LastName = "Moore", Age = 80, CreatedDateUtc = DateTime.UtcNow },
+];
+```
+
 ### Sorting
 Sorting can be done using the `ApplySort`. <br/>
 The following example shows how to sort the list of entities by the `Age` property in ascending order.

--- a/tests/FilteringTests.cs
+++ b/tests/FilteringTests.cs
@@ -163,7 +163,7 @@ public class FilteringTests
 		IQueryable<TestEntity> query = TestEntity.EntityList.AsQueryable();
 		var model = new FilterModel<TestEntity>
 		{
-			Operator = FilterOperator.Or,
+			Operator = FilterOperator.And,
 			Filters =
 			[
 				new FilterModel<TestEntity>


### PR DESCRIPTION
- Updated README to add examples for filtering using the Filters list inside the FilterModel.
- Fixed test method: `Should_Filter_Using_Filter_List` because it had a `FilterOperator`: `FilterOperator.Or` instead of `FilterOperator.And`.